### PR TITLE
Fix: date must be a Date instance

### DIFF
--- a/src/services/event-management/dto/event.dto.ts
+++ b/src/services/event-management/dto/event.dto.ts
@@ -7,6 +7,7 @@ import {
   IsInt,
 } from 'class-validator';
 import { EventStatus } from '@prisma/client';
+import { Type } from 'class-transformer';
 
 export class CreateEventDto {
   @IsString()
@@ -23,6 +24,7 @@ export class CreateEventDto {
   image?: string;
 
   @IsDate()
+  @Type(() => Date)
   date: Date;
 
   @IsOptional()


### PR DESCRIPTION
In create event endpoint, every time I pass a Date instance it returns this msg:

```json
{
    "status": "error",
    "message": "Bad input data",
    "error": {
        "date": "date must be a Date instance"
    }
}   
```
I tried the same line in `seed.ts` and still didn't work, my guess that stringfying and parsing json might be the problem, any ways here is a one line solution to cast it on validation in the DTO.

