### PR TITLE
Fix: CORS Options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ async function bootstrap() {
   Logger.log(`Allowed Origins ${process.env.origins}`);
 
   const corsOption = {
-    origin: process.env.origins,
+    origin: JSON.parse(process.env.origins),
     methods: 'GET, HEAD, PUT, PATCH, POST, DELETE',
     preflightContinue: false,
     optionsSuccessStatus: 204,


### PR DESCRIPTION
We should parse the origins array from env using `JSON.parse`, because without parsing it, its just another string in env not an array.