### PR TITLE
Include Id in GET admins

### DIFF
--- a/src/services/admin/admin.service.ts
+++ b/src/services/admin/admin.service.ts
@@ -20,6 +20,7 @@ export class AdminService {
   async findAll() {
     return await this.prisma.superUser.findMany({
       select: {
+        id: true,
         name: true,
         email: true,
         createdAt: true,


### PR DESCRIPTION
To be able to perform methods like reseting passwords and revoke access, we need the id in the get method.